### PR TITLE
Update for mlpack 4.8.0 API change

### DIFF
--- a/R/stat-spantree.r
+++ b/R/stat-spantree.r
@@ -120,9 +120,13 @@ StatSpantree <- ggproto(
           )
         }
         # minimum spanning tree (euclidean distance)
-        data_emst <- mlpack::emst(data_ord)
+        if (packageVersion("mlpack") < "4.8.0") {
+          data_emst <- mlpack::emst(data_ord)$output
+        } else {
+          data_emst <- mlpack::emst(data_ord)
+        }
         # re-index pairs
-        data_emst$output[, 1:2] + 1L
+        data_emst[, 1:2] + 1L
       },
       vegan = {
         # distance/dissimilarity data


### PR DESCRIPTION
Hi there,

I'm glad you found mlpack useful in your work here. We just did a release for version 4.8.0 and due to a little bit of an oversight, the API for mlpack::emst ended up changing (normally we try to keep API-changing releases as major release bumps). I would say it's for the better: instead of awkwardly returning a one-element list, it now returns just the output matrix itself.

Anyway, this diff allows compatibility with both old and new versions. Note that *I did not test this*, but it should work. You should definitely test it on your end.

If you prefer, you could just remove the $output instead and we can submit updated versions of both gggda and mlpack 4.8.0 to CRAN at the same time; let me know what you think.

Thanks so much!